### PR TITLE
Cycles are now stored in the SKSE cosave file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,55 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "cc"
@@ -82,7 +127,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -99,7 +144,7 @@ checksum = "b8fcfa71f66c8563c4fa9dd2bb68368d50267856f831ac5d85367e0805f9606c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -118,6 +163,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +177,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -230,12 +290,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rend"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -261,6 +384,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "serde"
 version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,7 +406,7 @@ checksum = "6e5c3a298c7f978e53536f95a63bdc4c4a64550582f31a0359a9afda6aede62e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -288,6 +417,12 @@ checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "simplelog"
@@ -309,6 +444,7 @@ dependencies = [
  "cxx-build",
  "log",
  "once_cell",
+ "rkyv",
  "rust-ini",
  "serde",
  "simplelog",
@@ -335,7 +471,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.27",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -348,6 +495,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
@@ -397,6 +550,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +611,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,4 +666,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.71"
 cxx = { version = "1.0.100", features = ["c++20"] }
 log = "0.4.19"
 once_cell = "1.18.0"
+rkyv = { version = "0.7.42", features = ["validation"] }
 rust-ini = "0.19.0"
 serde = { version = "1.0.167", features = ["derive"] }
 simplelog = "0.12.1"

--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -7,6 +7,7 @@ set(headers ${headers}
     src/game/shouts.h
     src/game/utility.h
     src/game/weapons.h
+    src/plugin/cosave.h
     src/plugin/hooks.h
     src/plugin/keycodes.h
     src/plugin/papyrus.h
@@ -30,6 +31,7 @@ set(sources ${sources}
     src/game/utility.cpp
     src/game/weapons.cpp
     src/main.cpp
+    src/plugin/cosave.cpp
     src/plugin/hooks.cpp
     src/plugin/keycodes.cpp
     src/plugin/papyrus.cpp

--- a/src/controller/control.rs
+++ b/src/controller/control.rs
@@ -121,6 +121,21 @@ pub mod public {
             .expect("Unrecoverable runtime problem: cannot acquire controller lock. Exiting.");
         ctrl.apply_settings();
     }
+
+    /// Serialize cycles for cosave test.
+    pub fn serialize_cycles() -> Vec<u8> {
+        let ctrl = CONTROLLER
+            .lock()
+            .expect("Unrecoverable runtime problem: cannot acquire controller lock. Exiting.");
+        ctrl.cycles.serialize()
+    }
+
+    /// Cycle data loaded from cosave.
+    pub fn cycle_loaded_from_cosave(buffer: Vec<u8>) {
+        // don't do anything with it yet, but deserialize it and see how it looks
+        let mut test_cycle = CycleData::deserialize(buffer);
+        test_cycle.validate();
+    }
 }
 
 /// What, model/view/controller? In my UI application? oh no

--- a/src/controller/control.rs
+++ b/src/controller/control.rs
@@ -134,7 +134,10 @@ pub mod public {
     pub fn cycle_loaded_from_cosave(buffer: Vec<u8>) {
         // don't do anything with it yet, but deserialize it and see how it looks
         let mut test_cycle = CycleData::deserialize(buffer);
+        log::info!("-------- begin cosave validation ----------");
         test_cycle.validate();
+        log::info!("-------- end cosave validation ----------");
+
     }
 }
 

--- a/src/controller/cycles.rs
+++ b/src/controller/cycles.rs
@@ -28,51 +28,6 @@ pub struct CycleData {
 static CYCLE_PATH: &str = "./data/SKSE/Plugins";
 
 impl CycleData {
-    /// Write the cycle data to its file.
-    fn cycle_storage() -> PathBuf {
-        let name = playerName()
-            .trim()
-            .replace(' ', "_")
-            .replace(['\\', '\''], "");
-        PathBuf::from(CYCLE_PATH).join(format!("SoulsyHUD_{}_Cycles.toml", name))
-    }
-
-    /// Write serialized toml to the cycle storage file for this character.
-    pub fn write(&self) -> Result<()> {
-        log::info!(
-            "writing cycles to disk; lengths are: powers={}; utilities={}; left={}; right={};",
-            self.power.len(),
-            self.utility.len(),
-            self.left.len(),
-            self.right.len()
-        );
-        let buf = toml::to_string(self)?;
-        std::fs::write(CycleData::cycle_storage(), buf)?;
-        log::trace!(
-            "wrote cycle data to {}",
-            CycleData::cycle_storage().display()
-        );
-        Ok(())
-    }
-
-    /// Read cycle data from the serialization file for this character.
-    pub fn read() -> Result<Self> {
-        let buf = std::fs::read_to_string(CycleData::cycle_storage())?;
-        let data = toml::from_str::<CycleData>(&buf)?;
-        log::info!(
-            "read cycle data from {}; initial cycle lengths are:",
-            CycleData::cycle_storage().display()
-        );
-        log::info!(
-            "powers={}; utilities={}; left={}; right={};",
-            data.power.len(),
-            data.utility.len(),
-            data.left.len(),
-            data.right.len()
-        );
-        Ok(data)
-    }
-
     /// Advance the given cycle by one. Returns a copy of the newly-top item.
     ///
     /// Called when the player presses a hotkey bound to one of the cycle slots.
@@ -139,41 +94,6 @@ impl CycleData {
             Action::Utility => self.utility.len(),
             _ => 0,
         }
-    }
-
-    /// Remove any items that have vanished from the game or from the player's
-    /// inventory.
-    pub fn validate(&mut self) {
-        let to_check = vec![
-            (Action::Power, "power"),
-            (Action::Utility, "utility"),
-            (Action::Left, "left"),
-            (Action::Right, "right"),
-        ];
-        to_check.iter().for_each(|xs| {
-            let action = xs.0;
-            let name = xs.1;
-            let cycle = match action {
-                Action::Power => &self.power,
-                Action::Utility => &self.utility,
-                Action::Left => &self.left,
-                Action::Right => &self.right,
-                _ => &self.power, // I hate non-exhaustive matching
-            };
-            log::info!("validating {name} cycle");
-            cycle.iter().for_each(|item| {
-                cxx::let_cxx_string!(form_spec = item.form_string());
-                let hasit = item.kind().is_ammo() || hasItemOrSpell(&form_spec);
-                log::info!(
-                    "    {}: name='{}'; form={}; player has={};",
-                    name,
-                    item.name(),
-                    item.form_string(),
-                    hasit
-                );
-            });
-        });
-        log::info!("Informational only. No changes made to cycle data. Have a nice day and remember to put on a cloak if it starts snowing.");
     }
 
     /// Attempt to set the current item in a cycle to the given form spec (mod.esp|formid).
@@ -369,11 +289,100 @@ impl CycleData {
         self.hud_visible
     }
 
+    // ---------- validation
+
+    /// Remove any items that have vanished from the game or from the player's
+    /// inventory.
+    pub fn validate(&mut self) {
+        let to_check = vec![
+            (Action::Power, "power"),
+            (Action::Utility, "utility"),
+            (Action::Left, "left"),
+            (Action::Right, "right"),
+        ];
+        to_check.iter().for_each(|xs| {
+            let action = xs.0;
+            let name = xs.1;
+            let cycle = match action {
+                Action::Power => &self.power,
+                Action::Utility => &self.utility,
+                Action::Left => &self.left,
+                Action::Right => &self.right,
+                _ => &self.power, // I hate non-exhaustive matching
+            };
+            log::info!("validating {name} cycle");
+            cycle.iter().for_each(|item| {
+                cxx::let_cxx_string!(form_spec = item.form_string());
+                let hasit = item.kind().is_ammo() || hasItemOrSpell(&form_spec);
+                log::info!(
+                    "    {}: name='{}'; kind={:?}; form={}; player has={};",
+                    name,
+                    item.name(),
+                    item.kind(),
+                    item.form_string(),
+                    hasit
+                );
+            });
+        });
+        log::info!("hud_visible: {}", self.hud_visible);
+        log::info!("Informational only. No changes made to cycle data. Have a nice day and remember to put on a cloak if it starts snowing.");
+    }
+
+    // ---------- TOML serialization
+
+    /// Write the cycle data to its file.
+    fn cycle_storage() -> PathBuf {
+        let name = playerName()
+            .trim()
+            .replace(' ', "_")
+            .replace(['\\', '\''], "");
+        PathBuf::from(CYCLE_PATH).join(format!("SoulsyHUD_{}_Cycles.toml", name))
+    }
+
+    /// Write serialized toml to the cycle storage file for this character.
+    pub fn write(&self) -> Result<()> {
+        log::info!(
+            "writing cycles to disk; lengths are: powers={}; utilities={}; left={}; right={};",
+            self.power.len(),
+            self.utility.len(),
+            self.left.len(),
+            self.right.len()
+        );
+        let buf = toml::to_string(self)?;
+        std::fs::write(CycleData::cycle_storage(), buf)?;
+        log::trace!(
+            "wrote cycle data to {}",
+            CycleData::cycle_storage().display()
+        );
+        Ok(())
+    }
+
+    /// Read cycle data from the serialization file for this character.
+    pub fn read() -> Result<Self> {
+        let buf = std::fs::read_to_string(CycleData::cycle_storage())?;
+        let data = toml::from_str::<CycleData>(&buf)?;
+        log::info!(
+            "read cycle data from {}; initial cycle lengths are:",
+            CycleData::cycle_storage().display()
+        );
+        log::info!(
+            "powers={}; utilities={}; left={}; right={};",
+            data.power.len(),
+            data.utility.len(),
+            data.left.len(),
+            data.right.len()
+        );
+        Ok(data)
+    }
+
+    // rkyv serialization to cosave
+
+
     pub fn serialize(&self) -> Vec<u8> {
         archive::serialize(self)
     }
 
-    pub fn deserialize(bytes: Vec<u8>) -> CycleData {
+    pub fn deserialize(bytes: Vec<u8>) -> Option<CycleData> {
         archive::deserialize(bytes)
     }
 }
@@ -406,7 +415,6 @@ mod archive {
     use rkyv::{Archive, Deserialize, Serialize};
 
     use super::{CycleData, ItemData};
-    use crate::plugin::ItemKind;
 
     // cosave implemention starts with a very packed set of bytes
     // I'm implementing this to the side of the toml so I can experiment.
@@ -418,7 +426,7 @@ mod archive {
         bytes.into_vec()
     }
 
-    pub fn deserialize(bytes: Vec<u8>) -> CycleData {
+    pub fn deserialize(bytes: Vec<u8>) -> Option<CycleData> {
         match rkyv::check_archived_root::<CycleSerialized>(&bytes[..]) {
             Ok(v) => {
                 if let Ok(deserialized) = <ArchivedCycleSerialized as rkyv::Deserialize<
@@ -427,7 +435,7 @@ mod archive {
                 >>::deserialize(v, &mut rkyv::Infallible)
                 {
                     log::info!("Loaded cycles from cosave successfully!");
-                    return deserialized.into();
+                    return Some(deserialized.into());
                 }
             }
             Err(e) => {
@@ -436,7 +444,7 @@ mod archive {
                 log::trace!("{bytes:?}");
             }
         }
-        CycleData::default()
+        None
     }
 
     #[derive(Archive, Deserialize, Serialize, Debug, PartialEq)]
@@ -500,7 +508,7 @@ mod archive {
     impl From<&ItemSerialized> for ItemData {
         fn from(value: &ItemSerialized) -> ItemData {
             ItemData::new(
-                ItemKind::Empty, // value.kind.into(),
+                value.kind.into(),
                 value.two_handed,
                 value.has_count,
                 value.count,

--- a/src/controller/itemkind.rs
+++ b/src/controller/itemkind.rs
@@ -254,3 +254,112 @@ static ICON_MAP: Lazy<HashMap<ItemKind, String>> = Lazy::new(|| {
         (ItemKind::Whip, "whip.svg".to_string()),
     ])
 });
+
+// This is horrific.
+impl From<u8> for ItemKind {
+    fn from(value: u8) -> Self {
+        if value == ItemKind::Empty.repr {
+            ItemKind::Empty
+        } else if value == ItemKind::Alteration.repr {
+            ItemKind::Alteration
+        } else if value == ItemKind::ArmorClothing.repr {
+            ItemKind::ArmorClothing
+        } else if value == ItemKind::ArmorHeavy.repr {
+            ItemKind::ArmorHeavy
+        } else if value == ItemKind::ArmorLight.repr {
+            ItemKind::ArmorLight
+        } else if value == ItemKind::Arrow.repr {
+            ItemKind::Arrow
+        } else if value == ItemKind::AxeOneHanded.repr {
+            ItemKind::AxeOneHanded
+        } else if value == ItemKind::AxeTwoHanded.repr {
+            ItemKind::AxeTwoHanded
+        } else if value == ItemKind::Bow.repr {
+            ItemKind::Bow
+        } else if value == ItemKind::Claw.repr {
+            ItemKind::Claw
+        } else if value == ItemKind::Conjuration.repr {
+            ItemKind::Conjuration
+        } else if value == ItemKind::Crossbow.repr {
+            ItemKind::Crossbow
+        } else if value == ItemKind::Dagger.repr {
+            ItemKind::Dagger
+        } else if value == ItemKind::DestructionFire.repr {
+            ItemKind::DestructionFire
+        } else if value == ItemKind::DestructionFrost.repr {
+            ItemKind::DestructionFrost
+        } else if value == ItemKind::DestructionShock.repr {
+            ItemKind::DestructionShock
+        } else if value == ItemKind::Destruction.repr {
+            ItemKind::Destruction
+        } else if value == ItemKind::Food.repr {
+            ItemKind::Food
+        } else if value == ItemKind::Halberd.repr {
+            ItemKind::Halberd
+        } else if value == ItemKind::HandToHand.repr {
+            ItemKind::HandToHand
+        } else if value == ItemKind::IconDefault.repr {
+            ItemKind::IconDefault
+        } else if value == ItemKind::Illusion.repr {
+            ItemKind::Illusion
+        } else if value == ItemKind::Katana.repr {
+            ItemKind::Katana
+        } else if value == ItemKind::Lantern.repr {
+            ItemKind::Lantern
+        } else if value == ItemKind::Mace.repr {
+            ItemKind::Mace
+        } else if value == ItemKind::Mask.repr {
+            ItemKind::Mask
+        } else if value == ItemKind::Pike.repr {
+            ItemKind::Pike
+        } else if value == ItemKind::PoisonDefault.repr {
+            ItemKind::PoisonDefault
+        } else if value == ItemKind::PotionDefault.repr {
+            ItemKind::PotionDefault
+        } else if value == ItemKind::PotionFireResist.repr {
+            ItemKind::PotionFireResist
+        } else if value == ItemKind::PotionFrostResist.repr {
+            ItemKind::PotionFrostResist
+        } else if value == ItemKind::PotionHealth.repr {
+            ItemKind::PotionHealth
+        } else if value == ItemKind::PotionMagicka.repr {
+            ItemKind::PotionMagicka
+        } else if value == ItemKind::PotionMagicResist.repr {
+            ItemKind::PotionMagicResist
+        } else if value == ItemKind::PotionShockResist.repr {
+            ItemKind::PotionShockResist
+        } else if value == ItemKind::PotionStamina.repr {
+            ItemKind::PotionStamina
+        } else if value == ItemKind::Power.repr {
+            ItemKind::Power
+        } else if value == ItemKind::QuarterStaff.repr {
+            ItemKind::QuarterStaff
+        } else if value == ItemKind::Rapier.repr {
+            ItemKind::Rapier
+        } else if value == ItemKind::Restoration.repr {
+            ItemKind::Restoration
+        } else if value == ItemKind::Scroll.repr {
+            ItemKind::Scroll
+        } else if value == ItemKind::Shield.repr {
+            ItemKind::Shield
+        } else if value == ItemKind::Shout.repr {
+            ItemKind::Shout
+        } else if value == ItemKind::SpellDefault.repr {
+            ItemKind::SpellDefault
+        } else if value == ItemKind::Staff.repr {
+            ItemKind::Staff
+        } else if value == ItemKind::SwordOneHanded.repr {
+            ItemKind::SwordOneHanded
+        } else if value == ItemKind::SwordTwoHanded.repr {
+            ItemKind::SwordTwoHanded
+        } else if value == ItemKind::Torch.repr {
+            ItemKind::Torch
+        } else if value == ItemKind::WeaponDefault.repr {
+            ItemKind::WeaponDefault
+        } else if value == ItemKind::Whip.repr {
+            ItemKind::Whip
+        } else {
+            ItemKind::Empty
+        }
+    }
+}

--- a/src/controller/itemkind.rs
+++ b/src/controller/itemkind.rs
@@ -255,7 +255,8 @@ static ICON_MAP: Lazy<HashMap<ItemKind, String>> = Lazy::new(|| {
     ])
 });
 
-// This is horrific.
+// This is horrific. There has to be a better way.
+// A way to iterate, perhaps?
 impl From<u8> for ItemKind {
     fn from(value: u8) -> Self {
         if value == ItemKind::Empty.repr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,6 +253,9 @@ pub mod plugin {
         fn initialize_hud();
         /// Check if the user wants the HUD visible right now or not.
         fn show_ui() -> bool;
+        /// Get cycle data for cosave.
+        fn serialize_cycles() -> Vec<u8>;
+        fn cycle_loaded_from_cosave(buffer: Vec<u8>);
 
         /// Give access to the settings to the C++ side.
         type UserSettings;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,7 +86,7 @@ EXTERN_C [[maybe_unused]] __declspec(dllexport) bool SKSEAPI SKSEPlugin_Load(con
 	}
 
 	Init(a_skse);
-	initializeCosaveSerialization();
+	cosave::initializeCosaves();
 
 	SKSE::AllocTrampoline(14 * 3);
 
@@ -138,14 +138,4 @@ EXTERN_C [[maybe_unused]] __declspec(dllexport) bool SKSEAPI
 	}
 
 	return true;
-}
-
-void initializeCosaveSerialization()
-{
-	log::trace("Initializing cosave serialization...");
-	auto* cosave = GetSerializationInterface();
-	cosave->SetUniqueID(_byteswap_ulong('SOLS'));
-	cosave->SetSaveCallback(cosave::gameSavedHandler);
-	cosave->SetRevertCallback(cosave::revertHandler);
-	cosave->SetLoadCallback(cosave::gameLoadedHandler);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include "cosave.h"
 #include "hooks.h"
 #include "papyrus.h"
 #include "sinks.h"
@@ -85,6 +86,7 @@ EXTERN_C [[maybe_unused]] __declspec(dllexport) bool SKSEAPI SKSEPlugin_Load(con
 	}
 
 	Init(a_skse);
+	initializeCosaveSerialization();
 
 	SKSE::AllocTrampoline(14 * 3);
 
@@ -136,4 +138,14 @@ EXTERN_C [[maybe_unused]] __declspec(dllexport) bool SKSEAPI
 	}
 
 	return true;
+}
+
+void initializeCosaveSerialization()
+{
+	log::trace("Initializing cosave serialization...");
+	auto* cosave = GetSerializationInterface();
+	cosave->SetUniqueID(_byteswap_ulong('SOLS'));
+	cosave->SetSaveCallback(cosave::gameSavedHandler);
+	cosave->SetRevertCallback(cosave::revertHandler);
+	cosave->SetLoadCallback(cosave::gameLoadedHandler);
 }

--- a/src/plugin/cosave.cpp
+++ b/src/plugin/cosave.cpp
@@ -7,6 +7,16 @@ inline const auto CYCLE_RECORD = _byteswap_ulong('CYCL');
 namespace cosave
 {
 
+	void initializeCosaves()
+	{
+		logger::trace("Initializing cosave serialization...");
+		auto* cosave = SKSE::GetSerializationInterface();
+		cosave->SetUniqueID(_byteswap_ulong('SOLS'));
+		cosave->SetSaveCallback(cosave::gameSavedHandler);
+		// cosave->SetRevertCallback(cosave::revertHandler);
+		cosave->SetLoadCallback(cosave::gameLoadedHandler);
+	}
+
 	void gameSavedHandler(SKSE::SerializationInterface* cosave)
 	{
 		if (!cosave->OpenRecord(CYCLE_RECORD, 0))
@@ -25,10 +35,12 @@ namespace cosave
 		for (iter = buffer.begin(); iter != buffer.end(); ++iter) { cosave->WriteRecordData(iter); }
 	}
 
+/*
 	void revertHandler(SKSE::SerializationInterface* cosave)
 	{
 		// TODO reset
 	}
+*/
 
 	void gameLoadedHandler(SKSE::SerializationInterface* cosave)
 	{

--- a/src/plugin/cosave.cpp
+++ b/src/plugin/cosave.cpp
@@ -1,0 +1,59 @@
+#include "cosave.h"
+
+#include "lib.rs.h"
+
+inline const auto CYCLE_RECORD = _byteswap_ulong('CYCL');
+
+namespace cosave
+{
+
+	void gameSavedHandler(SKSE::SerializationInterface* cosave)
+	{
+		if (!cosave->OpenRecord(CYCLE_RECORD, 0))
+		{
+			logger::error("Unable to open record to write cosave data.");
+			return;
+		}
+
+		// The format is an ad-hoc bag of bytes that we interpret
+		// as we wish. What I'm going to do is serialize on the Rust side
+		// to a bag of bytes and then just write the bag.
+
+		rust::Vec<uint8_t> buffer = serialize_cycles();
+		cosave->WriteRecordData(buffer.size());
+		rust::Vec<uint8_t>::iterator iter;
+		for (iter = buffer.begin(); iter != buffer.end(); ++iter) { cosave->WriteRecordData(iter); }
+	}
+
+	void revertHandler(SKSE::SerializationInterface* cosave)
+	{
+		// TODO reset
+	}
+
+	void gameLoadedHandler(SKSE::SerializationInterface* cosave)
+	{
+		std::uint32_t type;
+		std::uint32_t version;
+		std::uint32_t size;
+
+		while (cosave->GetNextRecordInfo(type, version, size))
+		{
+			if (type == CYCLE_RECORD)
+			{
+				int bufferSize;
+				rust::Vec<uint8_t> buffer;
+				cosave->ReadRecordData(bufferSize);
+				for (; bufferSize > 0; --bufferSize)
+				{
+					// this feels staggeringly inefficient, but first I gotta make it work
+					uint8_t next;
+					cosave->ReadRecordData(next);
+					buffer.push_back(next);
+				}
+				cycle_loaded_from_cosave(buffer);
+			}
+			else { logger::warn("Unknown record type in cosave; type={}", type); }
+		}
+	}
+
+}

--- a/src/plugin/cosave.h
+++ b/src/plugin/cosave.h
@@ -1,7 +1,8 @@
 
 namespace cosave
 {
-	static void gameSavedHandler(SKSE::SerializationInterface* cosave);
-	static void revertHandler(SKSE::SerializationInterface* cosave);
-	static void gameLoadedHandler(SKSE::SerializationInterface* cosave);
+	void initializeCosaves();
+	void gameSavedHandler(SKSE::SerializationInterface* cosave);
+	void revertHandler(SKSE::SerializationInterface* cosave);
+	void gameLoadedHandler(SKSE::SerializationInterface* cosave);
 }

--- a/src/plugin/cosave.h
+++ b/src/plugin/cosave.h
@@ -1,0 +1,7 @@
+
+namespace cosave
+{
+	static void gameSavedHandler(SKSE::SerializationInterface* cosave);
+	static void revertHandler(SKSE::SerializationInterface* cosave);
+	static void gameLoadedHandler(SKSE::SerializationInterface* cosave);
+}

--- a/src/util/helpers.cpp
+++ b/src/util/helpers.cpp
@@ -231,7 +231,7 @@ namespace helpers
 
 		auto currentMult         = reinterpret_cast<float*>(getGlobalTimeMultPtr());
 		const auto desiredFactor = user_settings()->slow_time_factor();
-		float newFactor = (*currentMult) / desiredFactor;
+		float newFactor          = (*currentMult) / desiredFactor;
 		if (std::fabs(newFactor - 1.0f) < 0.01) { newFactor = 1.0f; }
 		*currentMult = newFactor;
 


### PR DESCRIPTION
We now write cycle data to the SKSE cosave file on game save, and read it on game load. This should drastically improve the stability of cycle data for players, since it will stay with a single character as they switch, or if they rename a character.

Some implementation notes:

The TOML serialization is still there as a backup, and indeed is required on the first load of a cosave-supporting plugin. Deserialization will need to be present until at least a 1.0 release, as removing it would be a breaking change. 

SKSE cosave serialization hands you a byte writer and reader and lets you define your own serialization format. So we take cycle data, serialize it into a bag of bytes, then write the entire bag of bytes. I'm using [rkyv](https://lib.rs/crates/rkyv) as a reasonable time/size tradeoff in the serialization format. My cycles are around 1460-ish bytes in length, which is just fine.

This was straightforward to do.