### PR TITLE
Handle strings that aren't valid UTF-8 without crashing

### DIFF
--- a/src/controller/itemkind.rs
+++ b/src/controller/itemkind.rs
@@ -22,7 +22,7 @@ pub fn kind_is_magic(kind: ItemKind) -> bool {
 /// We cannot derive default for shared enums, so we define it here.
 impl Default for ItemKind {
     fn default() -> Self {
-        ItemKind::NotFound
+        ItemKind::Empty
     }
 }
 

--- a/src/controller/settings.rs
+++ b/src/controller/settings.rs
@@ -175,8 +175,7 @@ impl UserSettings {
 
         self.how_to_toggle = read_from_ini(self.how_to_toggle, "uHowToggleInMenus", controls);
         self.menu_modifier = read_from_ini(self.menu_modifier, "iMenuModifierKey", controls);
-        self.link_to_favorites =
-            read_from_ini(self.link_to_favorites, "bLinkToFavorites", options);
+        self.link_to_favorites = read_from_ini(self.link_to_favorites, "bLinkToFavorites", options);
 
         self.how_to_activate = read_from_ini(self.how_to_activate, "uHowToActivate", controls);
         self.activate = read_from_ini(self.activate, "uUtilityActivateKey", controls);

--- a/src/game/equippable.cpp
+++ b/src/game/equippable.cpp
@@ -1,5 +1,6 @@
 #include "equippable.h"
 
+#include "helpers.h"
 #include "lib.rs.h"
 #include "player.h"
 
@@ -7,14 +8,19 @@ namespace equippable
 {
 	rust::Box<ItemData> makeItemDataFromForm(RE::TESForm* item_form)
 	{
+		if (!item_form) {
+			logger::warn("Called makeItemDataFromForm() with null pointer.");
+			return empty_itemdata();
+		}
+		logger::info("making itemdata for '{}'"sv, item_form->GetName());
 		bool two_handed         = equippable::requiresTwoHands(item_form);
 		std::string form_string = helpers::makeFormSpecString(item_form);
 		auto kind               = equippable::itemKindFromForm(item_form);
 		auto count              = player::getInventoryCountByForm(item_form);
 		bool show_count         = kind_has_count(kind);
-		std::string name        = item_form->GetName();
+		auto chonker            = helpers::chars_to_vec(item_form->GetName());
 
-		return itemdata_from_formdata(kind, two_handed, show_count, count, name, form_string);
+		return itemdata_from_formdata(kind, two_handed, show_count, count, std::move(chonker), form_string);
 	}
 
 	bool canInstantCast(RE::TESForm* item_form, const ItemKind kind)

--- a/src/game/gear.cpp
+++ b/src/game/gear.cpp
@@ -56,7 +56,7 @@ namespace game
 
 		if (!bound_obj)
 		{
-			// logger::trace("unable to find any bound objects for item; bailing. name='{}'; "sv, form->GetName());
+			logger::debug("unable to find any bound objects for item; bailing. name='{}'; "sv, form->GetName());
 			return 0;
 		}
 

--- a/src/game/player.cpp
+++ b/src/game/player.cpp
@@ -17,7 +17,19 @@ namespace player
 {
 	using string_util = util::string_util;
 
-	rust::String playerName() { return RE::PlayerCharacter::GetSingleton()->GetName(); }
+	rust::Vec<uint16_t> playerName()
+	{
+		auto* name   = RE::PlayerCharacter::GetSingleton()->GetName();
+		auto cbytes = helpers::chars_to_vec(name);
+		rust::Vec<uint16_t> bytes;
+		bytes.reserve(cbytes.size() + 1);
+		for (auto iter = cbytes.cbegin(); iter != cbytes.cend(); iter++)
+		{
+			bytes.push_back(*iter);
+		}
+
+		return std::move(bytes);
+	}
 
 	bool isInCombat() { return RE::PlayerCharacter::GetSingleton()->IsInCombat(); }
 
@@ -94,7 +106,8 @@ namespace player
 
 		const auto formspec = helpers::makeFormSpecString(current_ammo);
 		auto count          = inventoryCount(current_ammo, RE::FormType::Ammo, player);
-		return itemdata_from_formdata(ItemKind::Arrow, false, true, count, current_ammo->GetName(), formspec);
+		auto chonker        = helpers::chars_to_vec(current_ammo->GetName());
+		return itemdata_from_formdata(ItemKind::Arrow, false, true, count, std::move(chonker), formspec);
 	}
 
 	void unequipSlot(Action which)

--- a/src/game/player.h
+++ b/src/game/player.h
@@ -27,7 +27,7 @@ namespace player
 	rust::Box<ItemData> boundObjectLeftHand();
 	rust::Box<ItemData> boundObjectRightHand();
 
-	rust::String playerName();
+	rust::Vec<uint16_t> playerName();
 
 	bool isInCombat();
 	bool weaponsAreDrawn();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,8 @@ pub mod plugin {
 
     extern "Rust" {
         /// Tell the rust side where to log.
-        fn initialize_rust_logging(logdir: &CxxString);
+        fn initialize_rust_logging(logdir: &CxxVector<u16>);
+
         /// Trigger rust to read config, figure out what the player has equipped,
         /// and figure out what it should draw.
         fn initialize_hud();
@@ -294,15 +295,19 @@ pub mod plugin {
             two_handed: bool,
             has_count: bool,
             count: u32,
-            name: &str,
+            name_bytes: &CxxVector<u8>,
             form_string: &str,
         ) -> Box<ItemData>;
         /// Get the item category, fine-grained to help with icon choices.
         fn kind(self: &ItemData) -> ItemKind;
         /// Check if any UI for this item should be drawn highlighted. UNUSED.
         fn highlighted(self: &ItemData) -> bool;
-        /// Get the game's human-readable name for this item.
+        /// Get the underlying bytes of a possibly non-utf8 name for this item.
         fn name(self: &ItemData) -> String;
+        /// Check if the item name is representable in utf8.
+        fn name_is_utf8(self: &ItemData) -> bool;
+        /// Get the item name as a possibly-lossy utf8 string.
+        fn name_bytes(self: &ItemData) -> Vec<u8>;
         /// Check whether this item is stacked in inventory, like potions are.
         fn has_count(self: &ItemData) -> bool;
         /// Get how many of this item the player has. Updated on inventory changes.
@@ -311,6 +316,7 @@ pub mod plugin {
         fn empty_itemdata() -> Box<ItemData>;
         /// Make an item that represents hand-to-hand combat, aka an empty hand.
         fn hand2hand_itemdata() -> Box<ItemData>;
+        fn form_string(self: &ItemData) -> String;
 
         /// Check if this item category can be stacked in inventory.
         fn kind_has_count(kind: ItemKind) -> bool;
@@ -334,7 +340,12 @@ pub mod plugin {
         /// Update the entire HUD without any hints about what just changed.
         fn update_hud() -> bool;
         /// Handle equipment-changed events from the game.
-        fn handle_item_equipped(equipped: bool, item: Box<ItemData>, right: bool, left: bool) -> bool;
+        fn handle_item_equipped(
+            equipped: bool,
+            item: Box<ItemData>,
+            right: bool,
+            left: bool,
+        ) -> bool;
         /// Handle inventory-count changed events from the game.
         fn handle_inventory_changed(item: Box<ItemData>, delta: i32);
         /// Favoriting & unfavoriting.
@@ -378,6 +389,7 @@ pub mod plugin {
         fn enterSlowMotion();
         /// Exit slow time.
         fn exitSlowMotion();
+        /// Show the hud very briefly on a cycle change.
         fn show_briefly();
     }
 
@@ -387,7 +399,7 @@ pub mod plugin {
         include!("player.h");
 
         /// Get the player's name.
-        fn playerName() -> String;
+        fn playerName() -> Vec<u16>;
 
         /// Is the player in combat?
         fn isInCombat() -> bool;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,14 @@ void init_logger()
 		spdlog::set_default_logger(std::move(log));
 		spdlog::set_pattern("%H:%M:%S.%f [%l] %s(%#) %v"s);
 
-		initialize_rust_logging(path->string());
+		const auto input = path->generic_wstring();
+		std::vector<uint16_t> bytes;
+		bytes.reserve(input.length());
+		for (auto iter = input.cbegin(); iter != input.cend(); iter++)
+		{
+			bytes.push_back(static_cast<uint16_t>(*iter));
+		}
+		initialize_rust_logging(std::move(bytes));
 	}
 	catch (const std::exception& e)
 	{

--- a/src/renderer/ui_renderer.h
+++ b/src/renderer/ui_renderer.h
@@ -63,7 +63,7 @@ namespace ui
 			const ImVec2 size,
 			const float angle,
 			const Color color);
-		static void drawText(const char* text,
+		static void drawText(const std::string text,
 			const ImVec2 center,
 			const float font_size,
 			const Color color,

--- a/src/util/helpers.cpp
+++ b/src/util/helpers.cpp
@@ -12,6 +12,32 @@ namespace helpers
 {
 	using string_util = util::string_util;
 
+	// How you know I've been replaced by a pod person: if I ever declare that
+	// I love dealing with strings in systems programming languages.
+
+	std::vector<uint8_t> chars_to_vec(const char* input)
+	{
+		auto incoming_len = strlen(input);
+		if (incoming_len == 0) { return std::move(std::vector<uint8_t>()); }
+ 
+		std::vector<uint8_t> result;
+		result.reserve(incoming_len + 1);  // null terminator
+		for (auto* ptr = input; *ptr != 0; ptr++) { result.push_back(static_cast<uint8_t>(*ptr)); }
+		result.push_back(0x00);  // there it is
+		return std::move(result);
+	}
+
+	std::string vec_to_stdstring(rust::Vec<uint8_t> input)
+	{
+		auto chars =  new char[input.size()]; // the vec has a null byte terminator already
+		int counter = 0;
+		for (auto byte : input) { chars[counter++] = static_cast<char>(byte); }
+		auto result = std::string(chars);
+		delete chars;
+
+		return std::move(result);
+	}
+
 	// See UserEvents.h -- this is kMovement | kActivate | kMenu
 	// Handles photo mode and possibly others.
 	static constexpr auto suppressWhenSansControlFlags = static_cast<RE::ControlMap::UEFlag>(1036);
@@ -158,13 +184,13 @@ namespace helpers
 			form                    = data_handler->LookupForm(form_id, plugin);
 		}
 
-		if (form != nullptr)
-		{
-			logger::trace("found form id for form spec='{}'; name='{}'; formID={}",
-				a_str,
-				form->GetName(),
-				string_util::int_to_hex(form->GetFormID()));
-		}
+		// if (form != nullptr)
+		// {
+		// 	logger::trace("found form id for form spec='{}'; name='{}'; formID={}",
+		// 		a_str,
+		// 		form->GetName(),
+		// 		string_util::int_to_hex(form->GetFormID()));
+		// }
 
 		return form;
 	}

--- a/src/util/helpers.h
+++ b/src/util/helpers.h
@@ -12,7 +12,6 @@ namespace helpers
 	std::string makeFormSpecString(RE::TESForm* form);
 	// uint32_t getSelectedFormFromMenu(RE::UI*& a_ui);
 
-
 	void notifyPlayer(const std::string& message);
 	void startAlphaTransition(const bool shift, const float target);
 	void show_briefly();
@@ -30,9 +29,11 @@ namespace helpers
 
 	bool itemIsFavorited(RE::TESForm* item_form);
 
+	std::string vec_to_stdstring(rust::Vec<uint8_t> input);
+	std::vector<uint8_t> chars_to_vec(const char* input);
+
 	//void addCycleKeyword(const std::string& form_spec);
 	//void removeCycleKeyword(const std::string& form_spec);
-
 
 	struct MenuSelection
 	{


### PR DESCRIPTION
Rust strings are always valid UTF-8. Windows-native strings are not; apparently they're not even necessarily valid UTF-16. There are two places in the mod code where this might be an issue, and players have reported crashers related to both.

First case: logging to a file path that itself is not valid UTF-8, as well as saving the TOML version of the cycle data with a player name that is not valid UTF-8. This is what OsString was designed to cope with. PathBuf assumes UTF-8, but the `std::file` api accepts OsString. So for these cases, we get a `Vec<16>` from the C++ side and then construct an OsString from it.

The second case is item names, which might come from mods that are free to use whatever characters they wish. An item name, like the player name, is returned from the `TESForm` item as a C string. It uses characters that the Flash-based menus can display, which appear to want UCS-2 aka windows wide strings, sort of UTF-16 BE, which is why the translation files require that encoding. AFAICT. In this case, what we need to do is use some kind of encoding conversion at display time to re-encode the characters. I am not doing that. Instead I am doing this:

We now extract the bytes into a `Vec<u8>` and pass that over to the Rust `ItemData` struct. This struct attempts to make a valid UTF-8 string out of it. If it can, that's what it uses to show the data. If it can't, it uses a lossy string. The same bytes are handed to `imgui`'s text drawing API as a C string, which does the same lossy display.

This is sub-optimal, but far better than crashing.

I have tested the item name case to my satisfaction. I have not yet tested the filepath case.

This PR should fix #32 "handle non-UTF-8 data".