### PR TITLE
Cosaves can be versioned; move to a version 1

### DIFF
--- a/src/controller/facade.rs
+++ b/src/controller/facade.rs
@@ -53,10 +53,9 @@ pub fn initialize_hud() {
     let _hud = hud_layout();
     ctrl.apply_settings();
     if !ctrl.cycles.loaded {
-        log::info!("Cosave data not found. Falling back to toml or defaults.");
-        ctrl.cycles = CycleData::read().unwrap_or_default();
+        log::info!("Cosave data not found. Falling back to defaults.");
+        ctrl.cycles = CycleData::default();
     }
-    // ctrl.update_hud();
 }
 
 /// Function for C++ to call to send a relevant button event to us.
@@ -133,10 +132,10 @@ pub fn cycle_loaded_from_cosave(bytes: &CxxVector<u8>) {
     let mut ctrl = control::get();
     if let Some(cosave_cycle) = CycleData::deserialize(bytes) {
         ctrl.cycles = cosave_cycle;
+        ctrl.validate_cycles();
         log::info!("Cycles loaded and ready to rock.");
     } else {
-        log::warn!("Cosave load failed. Staying with TOML fallback.");
-        ctrl.cycles = CycleData::read().unwrap_or_default();
+        log::warn!("Cosave load failed. Defaulting to fresh start.");
+        ctrl.cycles = CycleData::default();
     }
-    ctrl.validate_cycles();
 }

--- a/src/controller/facade.rs
+++ b/src/controller/facade.rs
@@ -53,7 +53,7 @@ pub fn initialize_hud() {
     let _hud = hud_layout();
     ctrl.apply_settings();
     if !ctrl.cycles.loaded {
-        log::info!("Cosave data not found. Falling back to defaults.");
+        log::info!("Cosave data not yet loaded.");
         ctrl.cycles = CycleData::default();
     }
 }
@@ -122,15 +122,19 @@ pub fn refresh_user_settings() {
     control::get().apply_settings();
 }
 
+pub fn serialize_version() -> u32 {
+    CycleData::serialize_version()
+}
+
 /// Serialize cycles for cosave.
 pub fn serialize_cycles() -> Vec<u8> {
     control::get().cycles.serialize()
 }
 
 /// Cycle data loaded from cosave.
-pub fn cycle_loaded_from_cosave(bytes: &CxxVector<u8>) {
+pub fn cycle_loaded_from_cosave(bytes: &CxxVector<u8>, version: u32) {
     let mut ctrl = control::get();
-    if let Some(cosave_cycle) = CycleData::deserialize(bytes) {
+    if let Some(cosave_cycle) = CycleData::deserialize(bytes, version) {
         ctrl.cycles = cosave_cycle;
         ctrl.validate_cycles();
         log::info!("Cycles loaded and ready to rock.");

--- a/src/controller/facade.rs
+++ b/src/controller/facade.rs
@@ -4,6 +4,7 @@
 
 use std::ffi::OsString;
 use std::fs::File;
+#[cfg(target_os = "windows")]
 use std::os::windows::ffi::OsStringExt;
 use std::path::Path;
 
@@ -26,6 +27,9 @@ pub fn initialize_rust_logging(logdir: &cxx::CxxVector<u16>) {
         LevelFilter::Info
     };
 
+    #[cfg(any(target_os = "macos", target_os = "unix"))]
+    let chonky_path = OsString::from("placeholder");
+    #[cfg(target_os = "windows")]
     let chonky_path = OsString::from_wide(logdir.as_slice());
     let path = Path::new(chonky_path.as_os_str()).with_file_name("SoulsyHUD_rust.log");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,9 @@ pub mod plugin {
         fn show_ui() -> bool;
         /// Get cycle data for cosave.
         fn serialize_cycles() -> Vec<u8>;
-        fn cycle_loaded_from_cosave(bytes: &CxxVector<u8>);
+        /// Serialization format version.
+        fn serialize_version() -> u32;
+        fn cycle_loaded_from_cosave(bytes: &CxxVector<u8>, version: u32);
 
         /// Give access to the settings to the C++ side.
         type UserSettings;
@@ -393,6 +395,8 @@ pub mod plugin {
         fn show_briefly();
         /// Play an activation failed UI sound.
         fn honk();
+        /// Make a full rust-side item from a form spec string.
+        fn formSpecToItemData(form_spec: &CxxString) -> Box<ItemData>;
     }
 
     // A verbose shim between Rust and the PlayerCharacter type.

--- a/src/plugin/cosave.cpp
+++ b/src/plugin/cosave.cpp
@@ -3,6 +3,7 @@
 #include "lib.rs.h"
 
 inline const auto CYCLE_RECORD = _byteswap_ulong('CYCL');
+inline const auto FORMAT_VERSION = 1;
 
 namespace cosave
 {
@@ -19,7 +20,7 @@ namespace cosave
 
 	void gameSavedHandler(SKSE::SerializationInterface* cosave)
 	{
-		if (!cosave->OpenRecord(CYCLE_RECORD, 0))
+		if (!cosave->OpenRecord(CYCLE_RECORD, FORMAT_VERSION))
 		{
 			logger::error("Unable to open record to write cosave data.");
 			return;
@@ -46,9 +47,11 @@ namespace cosave
 		{
 			if (type == CYCLE_RECORD)
 			{
-				if (version != 0) {
-					logger::info("surprised to get version {}"sv, version);
+				if (version == 0)
+				{
+					logger::info("Reading version 0 cosave data and upgrading.");
 				}
+
 				uint32_t bufSize;
 				std::vector<uint8_t> buffer;
 				cosave->ReadRecordData(bufSize);
@@ -57,7 +60,7 @@ namespace cosave
 				const auto read = cosave->ReadRecordData(buffer.data(), bufSize);
 				buffer.resize(read);
 				logger::debug("read {} bytes from cosave; buffer len is {}"sv, read, buffer.size());
-				cycle_loaded_from_cosave(buffer);
+				cycle_loaded_from_cosave(buffer, version);
 			}
 			else { logger::warn("Unknown record type in cosave; type={}", type); }
 		}

--- a/src/util/helpers.cpp
+++ b/src/util/helpers.cpp
@@ -34,7 +34,7 @@ namespace helpers
 		std::vector<uint8_t> result;
 		result.reserve(incoming_len + 1);  // null terminator
 		for (auto* ptr = input; *ptr != 0; ptr++) { result.push_back(static_cast<uint8_t>(*ptr)); }
-		result.push_back(0x00);            // there it is
+		result.push_back(0x00);  // there it is
 		return std::move(result);
 	}
 
@@ -207,6 +207,12 @@ namespace helpers
 		return form;
 	}
 
+	rust::Box<ItemData> formSpecToItemData(const std::string& spec)
+	{
+		auto* form_item = formSpecToFormItem(spec);
+		if (!form_item) { return empty_itemdata(); }
+		return equippable::makeItemDataFromForm(form_item);
+	}
 
 	MenuSelection::MenuSelection(RE::FormID formid) : form_id(formid) {}
 

--- a/src/util/helpers.h
+++ b/src/util/helpers.h
@@ -6,9 +6,12 @@
 // decision-making that needs a single source of truth. It's
 // badly-named.
 
+struct ItemData;
+
 namespace helpers
 {
-	RE::TESForm* formSpecToFormItem(const std::string& a_str);
+	RE::TESForm* formSpecToFormItem(const std::string& spec);
+	rust::Box<ItemData> formSpecToItemData(const std::string& spec);
 	std::string makeFormSpecString(RE::TESForm* form);
 	// uint32_t getSelectedFormFromMenu(RE::UI*& a_ui);
 


### PR DESCRIPTION
Version 1 of the cosave format is a list of form strings with
no additional data, so we can de-serialize into anything.
Including, cough cough, the new struct used by the HUD in the
icon branch.

The Rust side now informs the C++ side which version number to
use when saving. It successfully reads v0 and v1, and writes v1.

Removed all code for writing TOML files to persist cycle state.
We can no longer read cycle data from TOML files, so this is a
breaking pre-1.0 change. It will require a minor version number
bump. We still use TOML for reading layouts, so the deps remain.