### PR TITLE
Fix CTD when trying to advance an empty cycle

### DIFF
--- a/src/controller/cycleentries.rs
+++ b/src/controller/cycleentries.rs
@@ -143,6 +143,9 @@ where
     }
 
     fn advance(&mut self, amount: usize) -> Option<T> {
+        if self.is_empty() {
+            return None;
+        }
         self.rotate_left(amount);
         self.first().cloned()
     }


### PR DESCRIPTION
Hey, it's me again with another CTD !

I duplicated the guard in `advance_skipping` when a cycle is empty, otherwise `rotate_left` panics.

I resorted to log debugging as I wasn't sure how to pin point the issue with just crash logs, sometimes the stacktrace didn't mention this `advance` function at all. I suppose this is a tradeoff when using an extern library.