### PR TITLE
fix(input): overlapping modifiers not consistently respected

### DIFF
--- a/src/controller/settings.rs
+++ b/src/controller/settings.rs
@@ -318,9 +318,10 @@ impl UserSettings {
         }
     }
 
-    pub fn start_long_press_timer(&self, key: &Hotkey) -> bool {
-        let is_hand_cycle = matches!(key, Hotkey::Left | Hotkey::Right);
-        let can_be_unequipped = matches!(key, Hotkey::Left | Hotkey::Power | Hotkey::Right);
+    pub fn should_start_long_press_timer(&self, key: u32) -> bool {
+        let hotkey = Hotkey::from(key);
+        let is_hand_cycle = matches!(hotkey, Hotkey::Left | Hotkey::Right);
+        let can_be_unequipped = matches!(hotkey, Hotkey::Left | Hotkey::Power | Hotkey::Right);
 
         // These three should be mutually exclusive, so order shouldn't matter.
         // "should" ha ha ha
@@ -329,7 +330,7 @@ impl UserSettings {
         }
         if matches!(self.how_to_activate, ActivationMethod::LongPress)
             && matches!(
-                key,
+                hotkey,
                 Hotkey::Left | Hotkey::Power | Hotkey::Right | Hotkey::Utility
             )
         {

--- a/src/data/item_cache.rs
+++ b/src/data/item_cache.rs
@@ -47,6 +47,10 @@ impl ItemCache {
         self.lru.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.lru.is_empty()
+    }
+
     /// On load from save, we do not bother attempting to reconcile what
     /// we have cached with what the save state is. We merely enjoy the
     /// eternal sunshine of the spotless mind.


### PR DESCRIPTION
Bug #115 complains that the player couldn't set the unequip modifier and the utility-activation modifier to the same thing and have them consistently respected. When I looked into this I was horrified to read what a mess I'd made of tracking key input.

It's still a mess after this PR, but it's less of a mess. And this fixes #115.

We demote the hotkey enum to a supporting role instead of a central one. The controller uses the keycode as the identifier for tracked keys, since it is in fact unique while hotkeys, as noted above, might not be. The modifier hotkey variants have been collapsed into a single variant with internal data representing what modifiers might be associated with that keypress (sadly via a new enum, `Modifier`). The controller passes the tracked key struct down through key event handlers when needed, instead of the hotkey variant. It also uses the `Action` enum--which is definitely staying around--when that is meaningful.

I didn't get to nuke some enum types from orbit yet, but I will soon.