### PR TITLE
feature: Let's start scaling when display tweaks is active

### DIFF
--- a/src/controller/settings.rs
+++ b/src/controller/settings.rs
@@ -762,6 +762,12 @@ impl DisplayTweaks {
         self.update_from_ini(&fpath);
         let fpath = std::path::Path::new("Data/SKSE/Plugins/SSEDisplayTweaks_Custom.ini");
         self.update_from_ini(&fpath);
+
+        log::trace!(
+            "display tweaks scaling: {}; scale={};",
+            self.upscaling,
+            self.scale
+        );
     }
 
     fn update_from_ini(&mut self, fpath: &Path) {
@@ -771,17 +777,13 @@ impl DisplayTweaks {
         let Ok(conf) = Ini::load_from_file(fpath) else {
             return;
         };
-        let section = conf.general_section();
+        let Some(section) = conf.section(Some("Render")) else {
+            return;
+        };
         self.upscaling = read_from_ini(self.upscaling, "BorderlessUpscale", section);
         self.scale = read_from_ini(self.scale, "ResolutionScale", section);
     }
 }
-
-/*
-const wchar_t* defaultDisplayTweaksPath{ L"Data/SKSE/Plugins/SSEDisplayTweaks.ini" };
-    const wchar_t* userDisplayTweaksPath{ L"Data/SKSE/Plugins/SSEDisplayTweaks_Custom.ini" };
-    read ResolutionScale (double) and BorderlessUpscale (bool) from ini
-*/
 
 impl Default for DisplayTweaks {
     fn default() -> Self {

--- a/src/controller/settings.rs
+++ b/src/controller/settings.rs
@@ -477,6 +477,10 @@ impl UserSettings {
         u32::from_le_bytes(slice)
     }
 
+    pub fn is_upscaling(&self) -> bool {
+        self.display_tweaks.upscaling()
+    }
+
     pub fn resolution_scale(&self) -> f64 {
         self.display_tweaks.scale()
     }
@@ -749,11 +753,11 @@ struct DisplayTweaks {
 impl DisplayTweaks {
     /// Get the resolution scale, DisplayTweaks-aware.
     pub fn scale(&self) -> f64 {
-        if self.upscaling {
-            self.scale
-        } else {
-            1.0
-        }
+        self.scale
+    }
+
+    pub fn upscaling(&self) -> bool {
+        self.upscaling
     }
 
     /// Pluck scaling settings from the display tweaks ini.

--- a/src/layouts/layout_v2.rs
+++ b/src/layouts/layout_v2.rs
@@ -117,12 +117,14 @@ impl HudLayout2 {
     }
 
     fn flatten_slot(&self, slot: &SlotElement, element: HudElement) -> SlotFlattened {
+        let scale = self.global_scale;
+
         let bg = slot.background.clone().unwrap_or_default();
         let hotkey = slot.hotkey.clone().unwrap_or_default();
         let hkbg = hotkey.background.unwrap_or_default();
 
         let anchor = self.anchor_point();
-        let center = anchor.translate(&slot.offset.scale(self.global_scale));
+        let center = anchor.translate(&slot.offset.scale(scale));
         let text = slot
             .text
             .iter()
@@ -131,9 +133,9 @@ impl HudLayout2 {
 
         let poison = slot.poison.clone().unwrap_or_default();
         let poison_image = poison.indicator.svg;
-        let poison_size = poison.indicator.size.scale(self.global_scale);
+        let poison_size = poison.indicator.size.scale(scale);
         let poison_color = poison.indicator.color;
-        let poison_center = center.translate(&poison.offset.scale(self.global_scale));
+        let poison_center = center.translate(&poison.offset.scale(scale));
 
         let meter = slot.meter.clone().unwrap_or_default();
         let (
@@ -148,21 +150,21 @@ impl HudLayout2 {
             meter_start_angle,
             meter_end_angle,
             meter_arc_width,
-        ) = meter.tuple_for_flattening(&center, self.global_scale);
+        ) = meter.tuple_for_flattening(&center, scale);
 
         SlotFlattened {
             element,
             center: center.clone(),
-            bg_size: bg.size.scale(self.global_scale),
+            bg_size: bg.size.scale(scale),
             bg_color: bg.color,
             bg_image: bg.svg,
-            icon_size: slot.icon.size.scale(self.global_scale),
-            icon_center: slot.icon.offset.scale(self.global_scale).translate(&center),
+            icon_size: slot.icon.size.scale(scale),
+            icon_center: slot.icon.offset.scale(scale).translate(&center),
             icon_color: slot.icon.color.clone(),
-            hotkey_size: hotkey.size.scale(self.global_scale),
-            hotkey_center: hotkey.offset.scale(self.global_scale).translate(&center),
+            hotkey_size: hotkey.size.scale(scale),
+            hotkey_center: hotkey.offset.scale(scale).translate(&center),
             hotkey_color: hotkey.color,
-            hotkey_bg_size: hkbg.size.scale(self.global_scale),
+            hotkey_bg_size: hkbg.size.scale(scale),
             hotkey_bg_color: hkbg.color,
             hotkey_bg_image: hkbg.svg,
             poison_size,
@@ -185,12 +187,13 @@ impl HudLayout2 {
     }
 
     fn flatten_text(&self, text: &TextElement, center: &Point) -> TextFlattened {
+        let scale = self.global_scale;
         TextFlattened {
-            anchor: center.translate(&text.offset.scale(self.global_scale)),
+            anchor: center.translate(&text.offset.scale(scale)),
             color: text.color.clone(),
             alignment: text.alignment,
             contents: text.contents.clone(),
-            font_size: text.font_size * self.global_scale,
+            font_size: text.font_size * scale,
             wrap_width: text.wrap_width,
         }
     }
@@ -480,18 +483,19 @@ impl From<&HudLayout2> for LayoutFlattened {
             slots.push(v.flatten_slot(equipset, HudElement::EquipSet));
         }
         let bg = v.background.clone().unwrap_or_default();
+        let scale = v.global_scale;
 
         LayoutFlattened {
-            global_scale: v.global_scale,
+            global_scale: scale,
             anchor: v.anchor_point(),
-            size: v.size.scale(v.global_scale),
-            bg_size: bg.size.scale(v.global_scale),
+            size: v.size.scale(scale),
+            bg_size: bg.size.scale(scale),
             bg_color: bg.color.clone(),
             bg_image: bg.svg.clone(),
             hide_ammo_when_irrelevant: v.hide_ammo_when_irrelevant,
             hide_left_when_irrelevant: v.hide_left_when_irrelevant,
             font: v.font.clone(),
-            font_size: v.font_size * v.global_scale,
+            font_size: v.font_size * scale,
             chinese_full_glyphs: v.chinese_full_glyphs,
             simplified_chinese_glyphs: v.simplified_chinese_glyphs,
             cyrillic_glyphs: v.cyrillic_glyphs,
@@ -507,7 +511,7 @@ impl From<&HudLayout2> for LayoutFlattened {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::layouts::{resolutionHeight, Layout};
+    use crate::layouts::{displayHeight, Layout};
 
     #[test]
     fn default_layout_valid() {
@@ -746,7 +750,7 @@ mod tests {
             anchor,
             Point {
                 x: 190.0,
-                y: resolutionHeight() - layout.size.y
+                y: displayHeight() - layout.size.y
             }
         );
 

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -147,7 +147,6 @@ pub fn anchor_point(
     let height = size.y * global_scale;
 
     let user_pref_anchor = config.anchor_loc();
-    eprintln!("{user_pref_anchor}");
     let anchor_to_use = if !matches!(user_pref_anchor, &NamedAnchor::None) {
         user_pref_anchor
     } else {
@@ -197,8 +196,8 @@ pub fn anchor_point(
             } else {
                 // note the opportunity for refactoring but I am too stressed right now
                 Point {
-                    x: width / 2.0,
-                    y: height / 2.0,
+                    x: width * 0.5,
+                    y: height * 0.5,
                 }
             }
         }

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -139,13 +139,13 @@ pub fn anchor_point(
 ) -> Point {
     // If we read a named anchor point, turn it into pixels.
     // The anchor point is the location of the hud CENTER, so we offset.
-    let screen_width = resolutionWidth();
-    let screen_height = resolutionHeight();
+    let config = *user_settings();
+    let screen_width = displayWidth();
+    let screen_height = displayHeight();
 
     let width = size.x * global_scale;
     let height = size.y * global_scale;
 
-    let config = *user_settings();
     let user_pref_anchor = config.anchor_loc();
     eprintln!("{user_pref_anchor}");
     let anchor_to_use = if !matches!(user_pref_anchor, &NamedAnchor::None) {
@@ -232,19 +232,19 @@ impl Point {
 }
 
 #[cfg(not(test))]
-use crate::plugin::{resolutionHeight, resolutionWidth};
+use crate::plugin::{displayHeight, displayWidth};
 
 // Mocked screen resolution numbers, because these functions are provided by
 // C++ and require imgui etc. The names come from C++ and are not snake case.
 #[cfg(test)]
 #[allow(non_snake_case)]
-fn resolutionWidth() -> f32 {
+fn displayWidth() -> f32 {
     3440.0
 }
 
 #[cfg(test)]
 #[allow(non_snake_case)]
-fn resolutionHeight() -> f32 {
+fn displayHeight() -> f32 {
     1440.0
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,6 +551,9 @@ pub mod plugin {
         fn resolutionWidth() -> f32;
         /// Get the display height in pixels.
         fn resolutionHeight() -> f32;
+        fn displayWidth() -> f32;
+        fn displayHeight() -> f32;
+
         /// Start the named timer. Duration is looked up from settings.
         fn startTimer(which: Action, duration: u32);
         /// Stop the named timer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,6 +337,8 @@ pub mod plugin {
         fn log_level_number(self: &UserSettings) -> u32;
         /// The identifier to use for this mod in SKSE cosaves. Not exposed in UI.
         fn skse_identifier(self: &UserSettings) -> u32;
+        /// The display-tweaks aware resolution scale.
+        fn resolution_scale(self: &UserSettings) -> f64;
 
         /// After an MCM-managed change, re-read our .ini file.
         fn refresh_user_settings();

--- a/src/renderer/ui_renderer.cpp
+++ b/src/renderer/ui_renderer.cpp
@@ -672,7 +672,7 @@ namespace ui
 		std::string& imgDirectory)
 	{
 		const auto settings        = user_settings();
-		const auto resolutionScale = settings->scale();
+		const auto resolutionScale = settings->resolution_scale();
 
 		for (const auto& entry : std::filesystem::directory_iterator(imgDirectory))
 		{
@@ -708,8 +708,8 @@ namespace ui
 
 	void ui_renderer::loadAnimationFrames(std::string& file_path, std::vector<TextureData>& frame_list)
 	{
-		const auto settings        = user_settings();
-		const auto resolutionScale = settings->scale();
+		// const auto settings        = user_settings();
+		// const auto resolutionScale = settings->resolution_scale();
 
 		for (const auto& entry : std::filesystem::directory_iterator(file_path))
 		{
@@ -827,7 +827,7 @@ namespace ui
 	float resolutionWidth()
 	{
 		const auto settings = user_settings();
-		const auto scale    = settings->scale();
+		const auto scale    = static_cast<float>(settings->resolution_scale());
 		return scale * displayWidth();
 	}
 
@@ -835,7 +835,7 @@ namespace ui
 	float resolutionHeight()
 	{
 		const auto settings = user_settings();
-		const auto scale    = settings->scale();
+		const auto scale    = static_cast<float>(settings->resolution_scale());
 		return scale * displayHeight();
 	}
 

--- a/src/renderer/ui_renderer.cpp
+++ b/src/renderer/ui_renderer.cpp
@@ -671,8 +671,8 @@ namespace ui
 		std::map<uint32_t, TextureData>& textureCache,
 		std::string& imgDirectory)
 	{
-		const auto res_width  = resolutionScaleWidth();
-		const auto res_height = resolutionScaleHeight();
+		const auto settings        = user_settings();
+		const auto resolutionScale = settings->scale();
 
 		for (const auto& entry : std::filesystem::directory_iterator(imgDirectory))
 		{
@@ -700,14 +700,17 @@ namespace ui
 				}
 				else { rlog::error("failed to load texture {}"sv, entry.path().filename().string().c_str()); }
 
-				textureCache[index].width  = static_cast<int32_t>(textureCache[index].width * res_width);
-				textureCache[index].height = static_cast<int32_t>(textureCache[index].height * res_height);
+				textureCache[index].width  = static_cast<int32_t>(textureCache[index].width * resolutionScale);
+				textureCache[index].height = static_cast<int32_t>(textureCache[index].height * resolutionScale);
 			}
 		}
 	}
 
 	void ui_renderer::loadAnimationFrames(std::string& file_path, std::vector<TextureData>& frame_list)
 	{
+		const auto settings        = user_settings();
+		const auto resolutionScale = settings->scale();
+
 		for (const auto& entry : std::filesystem::directory_iterator(file_path))
 		{
 			ID3D11ShaderResourceView* texture = nullptr;
@@ -725,8 +728,8 @@ namespace ui
 			// rlog::trace("loading animation frame: {}"sv, entry.path().string().c_str());
 			TextureData img;
 			img.texture = texture;
-			// img.width   = static_cast<int32_t>(width * resolutionScaleWidth());
-			// img.height  = static_cast<int32_t>(height * resolutionScaleHeight());
+			// img.width   = static_cast<int32_t>(width * resolutionScale);
+			// img.height  = static_cast<int32_t>(height * resolutionScale);
 			frame_list.push_back(img);
 		}
 	}
@@ -820,18 +823,21 @@ namespace ui
 		rlog::trace("frame length is {}"sv, animation_frame_map[animation_type::highlight].size());
 	}
 
-	// These values scale the UI from the resolution the mod author used to the resolution
-	// of the player's screen. The effect is to make things not over-large for smaller resolutions.
-	// TODO this should be restored BUT as a lookup from the layout file. The designer can
-	// state their intent.
-	// float ui_renderer::resolutionScaleWidth() { return ImGui::GetIO().DisplaySize.x / 1920.f; }
-	// float ui_renderer::resolutionScaleHeight() { return ImGui::GetIO().DisplaySize.y / 1080.f; }
+	float displayWidth() { return ImGui::GetIO().DisplaySize.x; }
+	float resolutionWidth()
+	{
+		const auto settings = user_settings();
+		const auto scale    = settings->scale();
+		return scale * displayWidth();
+	}
 
-	float resolutionScaleWidth() { return 1.0f; }
-	float resolutionScaleHeight() { return 1.0f; }
-
-	float resolutionWidth() { return ImGui::GetIO().DisplaySize.x; }
-	float resolutionHeight() { return ImGui::GetIO().DisplaySize.y; }
+	float displayHeight() { return ImGui::GetIO().DisplaySize.y; }
+	float resolutionHeight()
+	{
+		const auto settings = user_settings();
+		const auto scale    = settings->scale();
+		return scale * displayHeight();
+	}
 
 	// Returns true if the HUD was invisible and we began showing it.
 	bool showBriefly()

--- a/src/renderer/ui_renderer.h
+++ b/src/renderer/ui_renderer.h
@@ -15,10 +15,12 @@ namespace ui
 		int32_t height                    = 0;
 	};
 
+	// display-tweaks aware
 	float resolutionWidth();
 	float resolutionHeight();
-	float resolutionScaleWidth();
-	float resolutionScaleHeight();
+	// from imgui's pov, unaware of scaling
+	float displayWidth();
+	float displayHeight();
 
 	void drawHud();
 


### PR DESCRIPTION
We now sneak a peek at the DisplayTweaks settings if we can find them, and adjust our sizes to account for any scaling or upscaling done behind Imgui's back.


If the window is downscaled, we include that in the layout's global scaling when flattening. If it's being upscaled afterward, we downscale twice to stay at a reasonable size. I do not think upscaling looks good, but at least everything is in the right place now.


Anchors specified via x & y coordinates are not affected by this scaling.