### PR TITLE
feat(layouts): text truncation & proper text alignment

### DIFF
--- a/docs/article-layouts-v2.md
+++ b/docs/article-layouts-v2.md
@@ -112,11 +112,13 @@ Each slot layout has a list of *text* elements. These describe text that should 
 
 Here are the fields a text element has:
 
-- `offset`: Where to draw this text, relative to the center of the slot
+- `offset`: Where to draw this text, relative to the center of the slot. This location is the *left edge* of the text box.
 - `alignment`: How to justify the text. Possible values are `left`, `center`, and `right`.
 - `font_size`: A floating-point number for the size of the type used.
 - `color`: The color to use to draw the text.
 - `contents`: A format string describing the text to draw.
+- `wrap_width`: The maximum allowed width of the text. If set, text is wrapped if it would be longer.
+` truncate`: A boolean value (`true` or `false`) indicating if the text should be cut short at the wrap width instead of wrapped. Set this to keep text at one line max.
 
 The data that can be filled into a format string is:
 
@@ -147,6 +149,8 @@ color = { r = 255, g = 255, b = 255, a = 255 }
 alignment = "left"
 contents = "{name}"
 font_size = 20.0
+wrap_width = 130.0
+truncate = false
 ```
 
 Any additional text elements for the power slot would also be named `[[power.text]]`. The double square brackets tells TOML that this is an [list of items](https://toml.io/en/v1.0.0#array-of-tables). Each new element named that is added to the end of the list.

--- a/src/layouts/layout_v1.rs
+++ b/src/layouts/layout_v1.rs
@@ -158,6 +158,7 @@ impl HudLayout1 {
                 contents: "{name}".to_string(),
                 font_size: slot.name_font_size * factor,
                 wrap_width: slot.name_wrap_width,
+                truncate: false,
             });
         }
         if slot.count_color.a > 0 {
@@ -168,6 +169,7 @@ impl HudLayout1 {
                 contents: "{count}".to_string(),
                 font_size: slot.count_font_size * factor,
                 wrap_width: slot.count_wrap_width,
+                truncate: false,
             });
         }
 

--- a/src/layouts/layout_v2.rs
+++ b/src/layouts/layout_v2.rs
@@ -196,6 +196,7 @@ impl HudLayout2 {
             contents: text.contents.clone(),
             font_size: text.font_size * scale,
             wrap_width: text.wrap_width,
+            truncate: text.truncate,
         }
     }
 
@@ -265,6 +266,8 @@ pub struct TextElement {
     bounds: Option<Point>,
     #[serde(default)]
     wrap_width: f32,
+    #[serde(default)]
+    truncate: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/src/layouts/mod.rs
+++ b/src/layouts/mod.rs
@@ -115,6 +115,9 @@ impl Layout {
         }
     }
 
+    /// Convert the editable human-facing layout format to the format used by
+    /// the renderer. This process scales all sizes and translates all locations
+    /// from relative to absolute in screen space.
     pub fn flatten(&self) -> LayoutFlattened {
         match self {
             // *v dereference the ref-to-box, **v unbox, &**v borrow
@@ -123,6 +126,7 @@ impl Layout {
         }
     }
 
+    /// Find the coordinates of the layout's location in screen space.
     pub fn anchor_point(&self) -> Point {
         match self {
             Layout::Version1(v) => v.anchor_point(),
@@ -131,6 +135,8 @@ impl Layout {
     }
 }
 
+/// An implementation detail of the anchor point calculation, used by both
+/// layout formats.
 pub fn anchor_point(
     global_scale: f32,
     size: &Point,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@ pub mod plugin {
         CircleArc,
     }
 
+    /// A text element in a form ready to use by the renderer.
     #[derive(Clone, Debug)]
     pub struct TextFlattened {
         anchor: Point,
@@ -175,10 +176,12 @@ pub mod plugin {
         contents: String,
         font_size: f32,
         wrap_width: f32,
+        truncate: bool,
     }
 
     /// This enum maps key presses to the desired action. More like a C/java
-    /// enum than a Rust sum type enum.
+    /// enum than a Rust sum type enum. It's also more like an event name than
+    /// a key press map at this point.
     #[derive(Debug, Clone, Hash)]
     enum Action {
         /// We do not need to do anything, possibly because the key was not one of our hotkeys.

--- a/src/renderer/ui_renderer.cpp
+++ b/src/renderer/ui_renderer.cpp
@@ -371,21 +371,23 @@ namespace ui
 		if (!font) { font = ImGui::GetDefaultFont(); }
 		const ImU32 textColor = IM_COL32(label->color.r, label->color.g, label->color.b, label->color.a * gHudAlpha);
 		ImVec2 alignedCenter  = ImVec2(center.x, center.y);
+		const auto* cstr      = text.c_str();
 
 		if (label->truncate && wrapWidth > 0.0f)
 		{
-			const char* here = ImGui::CalcWordWrapPositionA(1.0f, text.c_str(), nullptr, wrapWidth);
-			ImGui::GetWindowDrawList()->AddText(font, label->font_size, alignedCenter, textColor, text.c_str(), here);
+			const char* remainder = nullptr;
+			const auto bounds     = font->CalcTextSizeA(label->font_size, wrapWidth, 0.0f, cstr, nullptr, &remainder);
+			ImGui::GetWindowDrawList()->AddText(font, label->font_size, alignedCenter, textColor, cstr, remainder);
 			return;
 		}
 
 		// The imgui functions here handle wrapWidth=0 as no wrapping, which is what we want.
-		const ImVec2 bounds = font->CalcTextSizeA(label->font_size, wrapWidth, wrapWidth, text.c_str());
+		const ImVec2 bounds = font->CalcTextSizeA(label->font_size, wrapWidth, wrapWidth, cstr);
 		if (align == Align::Center) { alignedCenter.x += bounds.x * 0.5f; }
 		else if (align == Align::Right) { alignedCenter.x -= bounds.x; }
 
 		ImGui::GetWindowDrawList()->AddText(
-			font, fontSize, alignedCenter, textColor, text.c_str(), nullptr, wrapWidth, nullptr);
+			font, label->font_size, alignedCenter, textColor, cstr, nullptr, wrapWidth, nullptr);
 	}
 
 	void ui_renderer::initializeAnimation(const animation_type animation_type,

--- a/src/renderer/ui_renderer.h
+++ b/src/renderer/ui_renderer.h
@@ -48,11 +48,7 @@ namespace ui
 		const ImVec2 size,
 		const float angle,
 		const ImU32 im_color);  // retaining support for animations...
-	void drawText(const std::string text,
-		const ImVec2 center,
-		const float font_size,
-		const soulsy::Color color,
-		const Align alignment);
+	void drawText(const std::string text, const ImVec2 center, const TextFlattened* label);
 	void drawMeterCircleArc(float level, SlotFlattened slotLayout);
 	void drawMeterRectangular(float level, SlotFlattened slotLayout);
 	ImVec2 rotateVector(const ImVec2 vector, const float angle);
@@ -76,8 +72,6 @@ namespace ui
 
 		ui_renderer();
 
-		// Oxidation section.
-		// older...
 		static void initializeAnimation(animation_type animation_type,
 			float a_screen_x,
 			float a_screen_y,

--- a/src/soulsy.h
+++ b/src/soulsy.h
@@ -16,6 +16,7 @@ namespace soulsy
 	struct SlotFlattened;
 	struct SlotLayout;
 	struct SpellData;
+	struct TextFlattened;
 }
 
 using namespace soulsy;


### PR DESCRIPTION
You can now set `truncate` to true in a text element, like this:

```toml
wrap_width = 130.0
truncate = true
```

The text is truncated at the given wrap width instead of wrapped.

While I was truncating text and just generally figuring out what these
imgui functions do, I returned to the problem of correctly-aligning
wrapped text. For right- and center-aligned text, this requires 
looping through the full text rendering it one line at a time, 
adjusting the position of each line to match its bounds. Further,
because imgui does not export any of its word-wrapping implementation,
we have to do additional work to find word boundaries. To do this, 
we look for the nearest space preceding the imgui-selected wrap position.
If it's near enough, we break the line at that position, recalculate
bounds, and draw.

I broke out the text rendering cases so that simple cases do the least
work possible, and the space-seeking and bounds-adjusting work is only
done when required. The implementation of drawing text is somewhat 
verbose as a result but each case is simple by itself.

Fixes [#104](https://github.com/ceejbot/soulsy/issues/104)
Fixes [[#98](https://github.com/ceejbot/soulsy/issues/98)]