### PR TITLE
fix(hud): HUD not hidden when using Skyrim Souls

### DIFF
--- a/src/plugin/sinks.cpp
+++ b/src/plugin/sinks.cpp
@@ -22,8 +22,8 @@ void registerAllListeners()
 	// scriptEventSourceHolder->GetEventSource<RE::TESHitEvent>()->AddEventSink(listener);
 	// rlog::info("    hit events: {}"sv, typeid(RE::TESHitEvent).name());
 
-	// RE::UI::GetSingleton()->AddEventSink<RE::MenuOpenCloseEvent>(listener);
-	//rlog::info("    menu open/close events: {}"sv, typeid(RE::MenuOpenCloseEvent).name());
+	RE::UI::GetSingleton()->AddEventSink<RE::MenuOpenCloseEvent>(listener);
+	rlog::info("    menu open/close events: {}"sv, typeid(RE::MenuOpenCloseEvent).name());
 
 	RE::BSInputDeviceManager::GetSingleton()->AddEventSink(listener);
 	rlog::info("    player input events."sv);
@@ -99,8 +99,7 @@ RE::BSEventNotifyControl TheListener::ProcessEvent(const RE::TESHitEvent* event,
 RE::BSEventNotifyControl TheListener::ProcessEvent(const RE::MenuOpenCloseEvent* event,
 	[[maybe_unused]] RE::BSTEventSource<RE::MenuOpenCloseEvent>* source)
 {
-	// TODO; just logging for now
-	rlog::info("menu event: '{}' {}", event->menuName, event->opening ? "opened" : "closed");
+	if (event->menuName == "Cursor Menu") { helpers::setRelevantMenuOpen(event->opening); }
 	return RE::BSEventNotifyControl::kContinue;
 }
 

--- a/src/util/helpers.cpp
+++ b/src/util/helpers.cpp
@@ -131,16 +131,20 @@ namespace helpers
 		       ui->IsMenuOpen(RE::FavoritesMenu::MENU_NAME);
 	}
 
+	bool relevantMenuIsOpen = false;
+	void setRelevantMenuOpen(bool isOpen) { relevantMenuIsOpen = isOpen; }
+
 	bool hudAllowedOnScreen()
 	{
 		// There are some circumstances where we never want to draw it.
-		auto* ui              = RE::UI::GetSingleton();
-		bool hudInappropriate = !ui || ui->GameIsPaused() || !ui->IsCursorHiddenWhenTopmost() ||
-		                        !ui->IsShowingMenus() || !ui->GetMenu<RE::HUDMenu>() ||
-		                        ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME);
+		auto* ui = RE::UI::GetSingleton();
+		if (!ui) { return false; }
+		if (relevantMenuIsOpen) { return false; }
+		if (!playerInControl()) { return false; }
+		bool hudInappropriate = ui->GameIsPaused() || !ui->IsCursorHiddenWhenTopmost() || !ui->IsShowingMenus() ||
+		                        !ui->GetMenu<RE::HUDMenu>() || ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME);
 		if (hudInappropriate) { return false; }
 
-		if (!playerInControl()) { return false; }
 
 		return true;
 	}

--- a/src/util/helpers.h
+++ b/src/util/helpers.h
@@ -20,6 +20,7 @@ namespace helpers
 	void notifyPlayer(const std::string& message);
 	rust::String lookupTranslation(const std::string& key);
 
+	void setRelevantMenuOpen(bool isOpen);
 	bool hudAllowedOnScreen();  // the authority on whether we should show the hud or not
 	bool hudShouldAutoFadeOut();
 	bool hudShouldAutoFadeIn();


### PR DESCRIPTION
Any mod that un-pauses when menus are shown would trigger this bug. The fix is to track the visibility of the *cursor* via the cursor menu. If this is visible, the HUD should not be visible.

There are other cases where we should hide ourselves, but we already handle those, and those checks are untouched here. (It turned out pretty simple in the end!)